### PR TITLE
Add `postInstall()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 composer extension Change Log
 2.0.5 under development
 -----------------------
 
+- Enh #10: Added `yii\composer\Installer::postInstall()` method (rob006)
 - Bug #11: `generateCookieValidationKey()` now saves config file only when `cookieValidationKey` was generated (rob006)
 
 

--- a/Installer.php
+++ b/Installer.php
@@ -11,6 +11,7 @@ use Composer\Package\PackageInterface;
 use Composer\Installer\LibraryInstaller;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 use Composer\Util\Filesystem;
 
 /**
@@ -229,16 +230,34 @@ EOF
         }
     }
 
-    public static function postInstall($event)
-    {
-        static::runCommands($event, __METHOD__);
-    }
-
+    /**
+     * Special method to run tasks defined in `[extra][yii\composer\Installer::postCreateProject]` key in `composer.json`
+     *
+     * @param Event $event
+     */
     public static function postCreateProject($event)
     {
         static::runCommands($event, __METHOD__);
     }
 
+    /**
+     * Special method to run tasks defined in `[extra][yii\composer\Installer::postInstall]` key in `composer.json`
+     *
+     * @param Event $event
+     * @since 2.0.5
+     */
+    public static function postInstall($event)
+    {
+        static::runCommands($event, __METHOD__);
+    }
+
+    /**
+     * Special method to run tasks defined in `[extra][$extraKey]` key in `composer.json`
+     *
+     * @param Event $event
+     * @param string $extraKey
+     * @since 2.0.5
+     */
     protected static function runCommands($event, $extraKey)
     {
         $params = $event->getComposer()->getPackage()->getExtra();

--- a/Installer.php
+++ b/Installer.php
@@ -228,12 +228,22 @@ EOF
             rmdir($yiiDir);
         }
     }
-    
+
+    public static function postInstall($event)
+    {
+        static::runCommands($event, __METHOD__);
+    }
+
     public static function postCreateProject($event)
     {
+        static::runCommands($event, __METHOD__);
+    }
+
+    protected static function runCommands($event, $extraKey)
+    {
         $params = $event->getComposer()->getPackage()->getExtra();
-        if (isset($params[__METHOD__]) && is_array($params[__METHOD__])) {
-            foreach ($params[__METHOD__] as $method => $args) {
+        if (isset($params[$extraKey]) && is_array($params[$extraKey])) {
+            foreach ($params[$extraKey] as $method => $args) {
                 call_user_func_array([__CLASS__, $method], (array) $args);
             }
         }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ For example,
     "scripts": {
         "post-create-project-cmd": [
             "yii\\composer\\Installer::postCreateProject"
+        ],
+        "post-install-cmd": [
+            "yii\\composer\\Installer::postInstall"
         ]
     },
     "extra": {
@@ -64,7 +67,9 @@ For example,
                     "web/assets": "0777",
                     "yii": "0755"
                 }
-            ],
+            ]
+        },
+        "yii\\composer\\Installer::postInstall": {
             "generateCookieValidationKey": [
                 "config/web.php"
             ]


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Fixed issues | - |

This allows to define `post-install-cmd` scripts in the same manner as for `post-create-project-cmd`.
