### PR TITLE
`generateCookieValidationKey()` saves config file only when `cookieValidationKey` was generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 composer extension Change Log
 2.0.5 under development
 -----------------------
 
+- Bug #11: `generateCookieValidationKey()` now saves config file only when `cookieValidationKey` was generated (rob006)
 
 
 2.0.4 February 06, 2016

--- a/Installer.php
+++ b/Installer.php
@@ -271,8 +271,10 @@ EOF
         $key = self::generateRandomString();
         foreach ($configs as $config) {
             if (is_file($config)) {
-                $content = preg_replace('/(("|\')cookieValidationKey("|\')\s*=>\s*)(""|\'\')/', "\\1'$key'", file_get_contents($config));
-                file_put_contents($config, $content);
+                $content = preg_replace('/(("|\')cookieValidationKey("|\')\s*=>\s*)(""|\'\')/', "\\1'$key'", file_get_contents($config), -1, $count);
+                if ($count > 0) {
+                    file_put_contents($config, $content);
+                }
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | -

Right now `generateCookieValidationKey()` saves file even if there was no modifications.