### PR TITLE
Add `copyFiles()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 composer extension Change Log
 
 - Enh #10: Added `yii\composer\Installer::postInstall()` method (rob006)
 - Bug #11: `generateCookieValidationKey()` now saves config file only when `cookieValidationKey` was generated (rob006)
+- Enh #12: Added `yii\composer\Installer::copyFiles()` method (rob006)
 
 
 2.0.4 February 06, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Yii Framework 2 composer extension Change Log
 2.0.5 under development
 -----------------------
 
-- Enh #10: Added `yii\composer\Installer::postInstall()` method (rob006)
 - Bug #11: `generateCookieValidationKey()` now saves config file only when `cookieValidationKey` was generated (rob006)
+- Enh #10: Added `yii\composer\Installer::postInstall()` method (rob006)
 - Enh #12: Added `yii\composer\Installer::copyFiles()` method (rob006)
 
 

--- a/Installer.php
+++ b/Installer.php
@@ -324,6 +324,7 @@ EOF
      * for copied files (values). Location can be specified as an array - first element is target
      * location, second defines whether file can be overwritten (by default method don't overwrite
      * existing files).
+     * @since 2.0.5
      */
     public static function copyFiles(array $paths)
     {

--- a/Installer.php
+++ b/Installer.php
@@ -228,7 +228,7 @@ EOF
             rmdir($yiiDir);
         }
     }
-    
+
     public static function postCreateProject($event)
     {
         $params = $event->getComposer()->getPackage()->getExtra();
@@ -285,5 +285,44 @@ EOF
         $length = 32;
         $bytes = openssl_random_pseudo_bytes($length);
         return strtr(substr(base64_encode($bytes), 0, $length), '+/=', '_-.');
+    }
+
+    /**
+     * Copy files to specified locations.
+     * @param array $paths The source files paths (keys) and the corresponding target locations
+     * for copied files (values). Location can be specified as an array - first element is target
+     * location, second defines whether file can be overwritten (by default method don't overwrite
+     * existing files).
+     */
+    public static function copyFiles(array $paths)
+    {
+        foreach ($paths as $source => $target) {
+            // handle file target as array [path, overwrite]
+            $target = (array) $target;
+            echo "Copying file $source to $target[0] - ";
+
+            if (!is_file($source)) {
+                echo "source file not found.\n";
+                continue;
+            }
+
+            if (is_file($target[0]) && empty($target[1])) {
+                echo "target file exists - skip.\n";
+                continue;
+            } elseif (is_file($target[0]) && !empty($target[1])) {
+                echo "target file exists - overwrite - ";
+            }
+
+            try {
+                if (!is_dir(dirname($target[0]))) {
+                    mkdir(dirname($target[0]), 0777, true);
+                }
+                if (copy($source, $target[0])) {
+                    echo "done.\n";
+                }
+            } catch (\Exception $e) {
+                echo $e->getMessage() . "\n";
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -70,8 +70,16 @@ For example,
             ]
         },
         "yii\\composer\\Installer::postInstall": {
+            "copyFiles": [
+                {
+                    "config/templates/console-local.php": "config/console-local.php",
+                    "config/templates/web-local.php": "config/web-local.php",
+                    "config/templates/db-local.php": "config/db-local.php",
+                    "config/templates/cache.json": ["runtime/cache.json", true]
+                }
+            ],
             "generateCookieValidationKey": [
-                "config/web.php"
+                "config/web-local.php"
             ]
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | no |
| Fixed issues | - |

New helper method to simplify copying files in composer scripts.

``` json
{
    ...
    "scripts": {
        "post-create-project-cmd": [
            "yii\\composer\\Installer::postCreateProject"
        ]
    },
    "extra": {
        "yii\\composer\\Installer::postCreateProject": {
            "copyFiles": [
                {
                    "config/templates/console-local.php": "config/console-local.php",
                    "config/templates/web-local.php": ["config/web-local.php", true],
                    "config/templates/db-local.php": "config/db-local.php"
                }
            ]
        },
        ...
    }
}
```

TODO:
- [x] Implementation
- [x] Usage example in README
