### PR TITLE
Print a note about yii UPGRADE notes file

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -122,8 +122,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             if ($notes) {
                 // safety check: do not display notes if they are too many
                 if (count($notes) > 250) {
-                    $io->write("\n  <fg=yellow;options=bold>The relevant notes for your upgrade contain more than 250 lines,</>");
-                    $io->write("  <fg=yellow;options=bold>so they have not been displayed here.</>");
+                    $io->write("\n  <fg=yellow;options=bold>The relevant notes for your upgrade are too long to be displayed here.</>");
                 } else {
                     $io->write("\n  " . trim(implode("\n  ", $notes)));
                 }
@@ -134,6 +133,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $this->printUpgradeIntro($io, $package);
             $io->write("\n  You can find the upgrade notes online at:");
         }
+        $this->printUpgradeLink($io, $package);
+    }
+
+    /**
+     * Print link to upgrade notes
+     * @param IOInterface $io
+     * @param array $package
+     */
+    private function printUpgradeLink($io, $package)
+    {
         $maxVersion = $package['direction'] === 'up' ? $package['toPretty'] : $package['fromPretty'];
         // make sure to always show a valid link, even if $maxVersion is something like dev-master
         if (!$this->isNumericVersion($maxVersion)) {
@@ -194,6 +203,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function isNumericVersion($version)
     {
-        return preg_match('~^([0-9]\.[0-9]+\.[0-9]+)~', $version);
+        return preg_match('~^([0-9]\.[0-9]+\.?[0-9]*)~', $version);
     }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -8,8 +8,14 @@
 namespace yii\composer;
 
 use Composer\Composer;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Installer\PackageEvent;
+use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
+use Composer\Script;
+use Composer\Script\ScriptEvents;
 
 /**
  * Plugin is the composer plugin that registers the Yii composer installer.
@@ -17,8 +23,13 @@ use Composer\Plugin\PluginInterface;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
-class Plugin implements PluginInterface
+class Plugin implements PluginInterface, EventSubscriberInterface
 {
+    /**
+     * @var array noted package updates.
+     */
+    private $_packageUpdates = [];
+
     /**
      * @inheritdoc
      */
@@ -30,6 +41,65 @@ class Plugin implements PluginInterface
         if (!is_file($file)) {
             @mkdir(dirname($file), 0777, true);
             file_put_contents($file, "<?php\n\nreturn [];\n");
+        }
+    }
+
+    /**
+     * @inheritdoc
+     * @return array The event names to listen to.
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            PackageEvents::POST_PACKAGE_UPDATE => 'checkPackageUpdates',
+            ScriptEvents::POST_UPDATE_CMD => 'showUpgradeNotes',
+        ];
+    }
+
+
+    /**
+     * Listen to POST_PACKAGE_UPDATE event and take note of the package updates.
+     * @param PackageEvent $event
+     */
+    public function checkPackageUpdates(PackageEvent $event)
+    {
+        $operation = $event->getOperation();
+        if ($operation instanceof UpdateOperation) {
+            $this->_packageUpdates[$operation->getInitialPackage()->getName()] = [
+                'from' => $operation->getInitialPackage()->getVersion(),
+                'fromPretty' => $operation->getInitialPackage()->getPrettyVersion(),
+                'to' => $operation->getTargetPackage()->getVersion(),
+                'toPretty' => $operation->getTargetPackage()->getPrettyVersion(),
+                'direction' => $event->getPolicy()->versionCompare(
+                    $operation->getInitialPackage(),
+                    $operation->getTargetPackage(),
+                    '<'
+                ) ? 'up' : 'down',
+            ];
+        }
+    }
+
+    /**
+     * Listen to POST_UPDATE_CMD event to display information about upgrade notes if appropriate.
+     * @param Script\Event $event
+     */
+    public function showUpgradeNotes(Script\Event $event)
+    {
+        if (isset($this->_packageUpdates['yiisoft/yii2'])) {
+
+            $package = $this->_packageUpdates['yiisoft/yii2'];
+
+            $io = $event->getIO();
+
+            $io->write("\n  Seems you have "
+                . ($package['direction'] === 'up' ? 'upgraded' : 'downgraded')
+                . ' Yii Framework from version '
+                . $package['fromPretty'] . ' to ' . $package['toPretty'] . '.'
+            );
+            $io->write("\n  Please check the upgrade notes for possible incompatible changes");
+            $io->write('  and adjust your application code accordingly.');
+            $maxVersion = $package['direction'] === 'up' ? $package['toPretty'] : $package['fromPretty'];
+            $io->write("\n  Here is a link: https://github.com/yiisoft/yii2/blob/$maxVersion/framework/UPGRADE.md\n");
         }
     }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -143,6 +143,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
+     * Print upgrade intro    
      * @param IOInterface $io
      * @param array $package
      */

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "require": {
         "composer-plugin-api": "^1.0"
     },
+    "require-dev": {
+        "composer/composer": "^1.0"
+    },
     "autoload": {
         "psr-4": { "yii\\composer\\": "" }
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| New feature? | yes |
| Breaks BC? | no |

This adds a note about UPGRADE file after yii has been updated.
e.g.

```
$ composer update yiisoft/yii2 bower-asset/jquery.inputmask
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Removing bower-asset/jquery.inputmask (3.1.63)
  - Installing bower-asset/jquery.inputmask (3.2.7)
    Loading from cache

  - Removing yiisoft/yii2 (2.0.5)
  - Installing yiisoft/yii2 (2.0.7)
    Downloading: 100%

Writing lock file
Generating autoload files

  Seems you have upgraded Yii Framework from version 2.0.5 to 2.0.7.

  Please check the upgrade notes for possible incompatible changes
  and adjust your application code accordingly.

  Here is a link: https://github.com/yiisoft/yii2/blob/2.0.7/framework/UPGRADE.md

```
