### PR TITLE
Fixes a Zend OPcache error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 composer extension Change Log
 2.0.7 under development
 -----------------------
 
-- Fixed an error that would occur if the Zend OPcache extension was installed, but its "restrict_api" setting was enabled. 
+- Bug #18: Fixed an error that would occur if the Zend OPcache extension was installed, but its "restrict_api" setting was enabled (angrybrad)
 
 
 2.0.6 March 21, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 composer extension Change Log
 2.0.7 under development
 -----------------------
 
-- no changes in this release.
+- Fixed an error that would occur if the Zend OPcache extension was installed, but its "restrict_api" setting was enabled. 
 
 
 2.0.6 March 21, 2018

--- a/Installer.php
+++ b/Installer.php
@@ -158,7 +158,7 @@ class Installer extends LibraryInstaller
         }
         // invalidate opcache of extensions.php if exists
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($file, true);
+            @opcache_invalidate($file, true);
         }
         $extensions = require($file);
 


### PR DESCRIPTION
Fixes a "Zend OPcache API is restricted by "restrict_api" configuration directive" error if Zend OPache is installed, but that setting is enabled.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
