### PR TITLE
Fixes #23: Fixed an error that would occur if the Zend OPcache was enabled but restricted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 composer extension Change Log
 2.0.8 under development
 -----------------------
 
-- no changes in this release.
+- Bug #23: Fixed another an error that would occur if the Zend OPcache extension was installed, but its "restrict_api" setting was enabled (Lachee)
 
 
 2.0.7 July 05, 2018

--- a/Installer.php
+++ b/Installer.php
@@ -189,7 +189,7 @@ class Installer extends LibraryInstaller
         file_put_contents($file, "<?php\n\n\$vendorDir = dirname(__DIR__);\n\nreturn $array;\n");
         // invalidate opcache of extensions.php if exists
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($file, true);
+            @opcache_invalidate($file, true);
         }
     }
 


### PR DESCRIPTION
If the OPcache is set to restrictive, it will throw an exception on this line and abort the entire install process. As this line is already checked if it exists or not, it does not seem to be crucial for the installation process. The loadExtensions function has the same check and already throws away any errors as an example.

This is the continuation of Pull Request #18 and fixes the saveExtension too. 

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | #23 