### PR TITLE
Fix PHP error when upgrading/downgrading a Yii2 extesion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: php
 matrix:
   include:
     - php: 5.4
+      env: COMPOSER_VERSION=1.6.*
+    - php: 5.4
       env: COMPOSER_VERSION=1.9.*
     - php: 5.4
       env: COMPOSER_VERSION=1.10.*
@@ -12,6 +14,8 @@ matrix:
       env: COMPOSER_VERSION=2
 
     - php: 5.5
+      env: COMPOSER_VERSION=1.6.*
+    - php: 5.5
       env: COMPOSER_VERSION=1.9.*
     - php: 5.5
       env: COMPOSER_VERSION=1.10.*
@@ -19,6 +23,8 @@ matrix:
       env: COMPOSER_VERSION=2
 
     - php: 5.6
+      env: COMPOSER_VERSION=1.6.*
+    - php: 5.6
       env: COMPOSER_VERSION=1.9.*
     - php: 5.6
       env: COMPOSER_VERSION=1.10.*
@@ -26,6 +32,8 @@ matrix:
       env: COMPOSER_VERSION=2
 
     - php: 7.0
+      env: COMPOSER_VERSION=1.6.*
+    - php: 7.0
       env: COMPOSER_VERSION=1.9.*
     - php: 7.0
       env: COMPOSER_VERSION=1.10.*
@@ -33,6 +41,8 @@ matrix:
       env: COMPOSER_VERSION=2
 
     - php: 7.1
+      env: COMPOSER_VERSION=1.6.*
+    - php: 7.1
       env: COMPOSER_VERSION=1.9.*
     - php: 7.1
       env: COMPOSER_VERSION=1.10.*
@@ -40,6 +50,8 @@ matrix:
       env: COMPOSER_VERSION=2
 
     - php: 7.2
+      env: COMPOSER_VERSION=1.6.*
+    - php: 7.2
       env: COMPOSER_VERSION=1.9.*
     - php: 7.2
       env: COMPOSER_VERSION=1.10.*
@@ -47,12 +59,16 @@ matrix:
       env: COMPOSER_VERSION=2
 
     - php: 7.3
+      env: COMPOSER_VERSION=1.6.*
+    - php: 7.3
       env: COMPOSER_VERSION=1.9.*
     - php: 7.3
       env: COMPOSER_VERSION=1.10.*
     - php: 7.3
       env: COMPOSER_VERSION=2
 
+    - php: 7.4
+      env: COMPOSER_VERSION=1.6.*
     - php: 7.4
       env: COMPOSER_VERSION=1.9.*
     - php: 7.4

--- a/Plugin.php
+++ b/Plugin.php
@@ -13,6 +13,7 @@ use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
+use Composer\Package\Version\VersionParser;
 use Composer\Plugin\PluginInterface;
 use Composer\Script;
 use Composer\Script\ScriptEvents;
@@ -95,13 +96,31 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 'fromPretty' => $operation->getInitialPackage()->getPrettyVersion(),
                 'to' => $operation->getTargetPackage()->getVersion(),
                 'toPretty' => $operation->getTargetPackage()->getPrettyVersion(),
-                'direction' => $event->getPolicy()->versionCompare(
-                    $operation->getInitialPackage(),
-                    $operation->getTargetPackage(),
-                    '<'
-                ) ? 'up' : 'down',
+                'direction' => $this->_isUpgrade($event, $operation) ? 'up' : 'down',
             ];
         }
+    }
+
+    /**
+     * @param PackageEvent $event
+     * @param UpdateOperation $operation
+     * @return bool
+     */
+    private function _isUpgrade(PackageEvent $event, UpdateOperation $operation)
+    {
+        // Composer 1.7.0+
+        if (method_exists('Composer\Package\Version\VersionParser', 'isUpgrade')) {
+            return VersionParser::isUpgrade(
+                $operation->getInitialPackage()->getVersion(),
+                $operation->getTargetPackage()->getVersion()
+            );
+        }
+
+        return $event->getPolicy()->versionCompare(
+            $operation->getInitialPackage(),
+            $operation->getTargetPackage(),
+            '<'
+        );
     }
 
     /**


### PR DESCRIPTION
This PR fixes a PHP error that would occur when updating/downgrading a Yii2 extension using Composer 2, due to `Composer\Installer\PackageEvent::getPolicy()` having been removed (https://github.com/composer/composer/commit/006985a0ea7135408d9760125a74d862c17409cb).

The new code will check for whether `Composer\Package\Version\VersionParser::isUpgrade()` exists (added in Composer 1.7.0) and if so uses that. Otherwise sticks with the old code.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
