### PR TITLE
Use `random_bytes` instead of `openssl_random_pseudo_bytes` if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 composer extension Change Log
 2.0.11 under development
 ------------------------
 
-- no changes in this release.
+- Enh #38: Use `random_bytes` instead of `openssl_random_pseudo_bytes` if available (fetus_hina)
 
 
 2.0.10 June 24, 2020

--- a/Installer.php
+++ b/Installer.php
@@ -345,12 +345,22 @@ EOF
 
     protected static function generateRandomString()
     {
-        if (!extension_loaded('openssl')) {
-            throw new \Exception('The OpenSSL PHP extension is required by Yii2.');
-        }
         $length = 32;
-        $bytes = openssl_random_pseudo_bytes($length);
+        $bytes = self::generateRandomBytes($length);
         return strtr(substr(base64_encode($bytes), 0, $length), '+/=', '_-.');
+    }
+
+    protected static function generateRandomBytes($length)
+    {
+        if (function_exists('random_bytes')) {
+            return random_bytes($length);
+        }
+
+        if (extension_loaded('openssl')) {
+            return openssl_random_pseudo_bytes($length);
+        }
+
+        throw new \Exception('PHP >= 7.0 or the OpenSSL PHP extension is required by Yii2.');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | none

Note: CI is failing, but it isn't my scope.